### PR TITLE
Add BulletPhysics .so name for Ubuntu

### DIFF
--- a/physics.lisp
+++ b/physics.lisp
@@ -26,6 +26,7 @@
 
 (define-foreign-library libphysics
   ;; FIXME Search path
+  (:unix "libBulletDynamics.so")
   (t (:default "./libbullet")))
 
 (use-foreign-library libphysics)


### PR DESCRIPTION
With this PR the BulletPhysics wrapper (physics.lisp) compiles after installing the `libbullet-dev` package in Ubuntu. (Tested in 16.04 LTS)
